### PR TITLE
Increase Clojure version to 1.6.0 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <!-- core.rrb-vector depends on implementation details of vectors
          which were made public in Clojure 1.5.0 -->
-    <clojure.version>1.5.1</clojure.version>
+    <clojure.version>1.6.0</clojure.version>
     <clojure.warnOnReflection>true</clojure.warnOnReflection>
   </properties>
 


### PR DESCRIPTION
Alex Miller says build.clojure.org does not support any lower version
of Clojure as of Sep 2019 (and probably before then).