### PR TITLE
CRRBV-22 - Fix for off by one bug near 32^2 elements

### DIFF
--- a/src/main/cljs/clojure/core/rrb_vector/rrbt.cljs
+++ b/src/main/cljs/clojure/core/rrb_vector/rrbt.cljs
@@ -116,7 +116,7 @@
            shift (.-shift vec)
            root  (.-root vec)
            tail  (.-tail vec)]
-       (RRBChunkedSeq. vec (array-for cnt shift root tail i) i off nil nil)))
+       (RRBChunkedSeq. vec (array-for vec cnt shift root tail i) i off nil nil)))
   ([vec node i off]
      (RRBChunkedSeq. vec node i off nil nil))
   ([vec node i off meta]
@@ -296,7 +296,7 @@
   (-seq [this]
     (cond
       (zero? cnt) nil
-      (zero? (tail-offset cnt tail)) (array-seq tail)
+      (zero? (tail-offset this)) (array-seq tail)
       :else (rrb-chunked-seq this 0 0)))
 
   ICounted
@@ -410,8 +410,8 @@
         (Vector. (dec cnt) shift root new-tail meta nil))
 
       :else
-      (let [new-tail (array-for cnt shift root tail (- cnt 2))
-            root-cnt (tail-offset cnt tail)
+      (let [new-tail (array-for this cnt shift root tail (- cnt 2))
+            root-cnt (tail-offset this)
             new-root (pop-tail shift root-cnt (.-edit root) root)]
         (cond
           (nil? new-root)
@@ -433,7 +433,7 @@
   (-assoc-n [this i val]
     (cond
       (and (<= 0 i) (< i cnt))
-      (let [tail-off (tail-offset cnt tail)]
+      (let [tail-off (tail-offset this)]
         (if (>= i tail-off)
           (let [new-tail (make-array (alength tail))
                 idx (- i tail-off)]
@@ -481,7 +481,7 @@
     (loop [i    0
            j    0
            init init
-           arr  (array-for cnt shift root tail i)
+           arr  (array-for this cnt shift root tail i)
            lim  (dec (alength arr))
            step (inc lim)]
       (let [init (f init (+ i j) (aget arr j))]
@@ -491,7 +491,7 @@
             (recur i (inc j) init arr lim step)
             (let [i (+ i step)]
               (if (< i cnt)
-                (let [arr (array-for cnt shift root tail i)
+                (let [arr (array-for this cnt shift root tail i)
                       len (alength arr)
                       lim (dec len)]
                   (recur i 0 init arr lim len))
@@ -524,7 +524,7 @@
         (throw (js/Error. "start index greater than end index"))
 
         :else
-        (let [tail-off (tail-offset cnt tail)]
+        (let [tail-off (tail-offset this)]
           (if (>= start tail-off)
             (let [new-tail (make-array new-cnt)]
               (array-copy tail (- start tail-off)
@@ -544,7 +544,7 @@
                                     new-tail (make-array new-len)]
                                 (array-copy tail 0 new-tail 0 new-len)
                                 new-tail)
-                              (array-for new-cnt shift new-root (array)
+                              (array-for this new-cnt shift new-root (array)
                                          (dec new-cnt)))
                   new-root  (if tail-cut?
                               new-root
@@ -883,7 +883,7 @@
                      (aset arr 32 rngs)))
                  (->VectorNode nil arr))
                (fold-tail r1 s1
-                          (tail-offset (.-cnt v1) (.-tail v1))
+                          (tail-offset v1)
                           (.-tail v1)))
           s1 (if o? (+ s1 5) s1)
           r2 (.-root v2)
@@ -1023,7 +1023,7 @@
             this)
 
         :else
-        (let [new-tail-base (array-for cnt shift root tail (- cnt 2))
+        (let [new-tail-base (array-for this cnt shift root tail (- cnt 2))
               new-tail      (aclone new-tail-base)
               new-tidx      (alength new-tail-base)
               new-root      (pop-tail! shift cnt (.-edit root) root)]

--- a/src/main/cljs/clojure/core/rrb_vector/transients.cljs
+++ b/src/main/cljs/clojure/core/rrb_vector/transients.cljs
@@ -92,7 +92,7 @@
 (defn pop-tail! [shift cnt root-edit current-node]
   (let [ret (ensure-editable root-edit current-node)]
     (if (regular? ret)
-      (let [subidx (bit-and (bit-shift-right (dec cnt) shift) 0x1f)]
+      (let [subidx (bit-and (bit-shift-right (- cnt 2) shift) 0x1f)]
         (cond
           (> shift 5)
           (let [child (pop-tail! (- shift 5) cnt root-edit

--- a/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
@@ -881,7 +881,8 @@
   (popTail [this shift cnt node]
     (if (.regular nm node)
       (let [subidx (bit-and
-                    (bit-shift-right (unchecked-dec-int cnt) (int shift))
+                    (bit-shift-right (unchecked-subtract-int cnt (int 2))
+                                     (int shift))
                     (int 0x1f))]
         (cond
           (> (int shift) (int 5))

--- a/src/main/clojure/clojure/core/rrb_vector/transients.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/transients.clj
@@ -177,8 +177,9 @@
       (let [ret (.ensureEditable this nm am root-edit current-node shift)]
         (if (.regular nm ret)
           (let [subidx (bit-and
-                        (bit-shift-right (unchecked-dec-int cnt) shift)
-                        0x1f)]
+                        (bit-shift-right (unchecked-subtract-int cnt (int 2))
+                                         (int shift))
+                        (int 0x1f))]
             (cond
               (> shift 5)
               (let [child (.popTail this nm am

--- a/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
+++ b/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
@@ -1,5 +1,5 @@
 (ns clojure.core.rrb-vector.test-common
-  (:require [clojure.test :as test :refer [deftest is]]
+  (:require [clojure.test :as test :refer [deftest testing is]]
             [clojure.core.rrb-vector :as fv]))
 
 ;; The intent is to keep this file as close to
@@ -74,3 +74,13 @@
                       (fv/subvec 2)
                       (conj 2001))]
     (is (every? integer? (conj v1129-pre 2002)))))
+
+(deftest test-crrbv-22
+  (testing "pop! from a regular transient vector with 32*32+1 elements"
+    (let [v1025 (into (fv/vector) (range 1025))]
+      (is (= (persistent! (pop! (transient v1025)))
+             (range 1024)))))
+  (testing "pop from a persistent regular vector with 32*32+1 elements"
+    (let [v1025 (into (fv/vector) (range 1025))]
+      (is (= (pop v1025)
+             (range 1024))))))

--- a/src/test/clojure/clojure/core/rrb_vector/test_common.clj
+++ b/src/test/clojure/clojure/core/rrb_vector/test_common.clj
@@ -1,5 +1,5 @@
 (ns clojure.core.rrb-vector.test-common
-  (:require [clojure.test :as test :refer [deftest is]]
+  (:require [clojure.test :as test :refer [deftest testing is]]
             [clojure.core.rrb-vector :as fv]))
 
 ;; The intent is to keep this file as close to
@@ -74,3 +74,13 @@
                       (fv/subvec 2)
                       (conj 2001))]
     (is (every? integer? (conj v1129-pre 2002)))))
+
+(deftest test-crrbv-22
+  (testing "pop! from a regular transient vector with 32*32+1 elements"
+    (let [v1025 (into (fv/vector) (range 1025))]
+      (is (= (persistent! (pop! (transient v1025)))
+             (range 1024)))))
+  (testing "pop from a persistent regular vector with 32*32+1 elements"
+    (let [v1025 (into (fv/vector) (range 1025))]
+      (is (= (pop v1025)
+             (range 1024))))))


### PR DESCRIPTION
The change to the clj version here is motivated by the corresponding
code in Clojure's PersistentVector class, both for the persistent and
transient versions, in its popTail methods.  I believe one way to
think about why it is (cnt - 2) instead of (cnt - 1) here is that cnt
is the number of elements in the factor before it is pop'd, so (cnt -
1) is the new number of elements after popping.  (cnt - 2) is the
index of the new last element after popping.

The fix for the cljs version of the code is similar to the clj fix,
except that there is also a bug in tail-off that requires knowing
whether the vector is persistent or transient in order to return the
correct value.

An alternate fix, more similar to the Clojure version, would make
tailoff a method of a protocol that types Vector and Transient
implement differently.