### PR TITLE
CRRBV-13: Fix for the issue

### DIFF
--- a/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
@@ -1001,9 +1001,10 @@
               (.aset am arr (bit-and i (int 0x1f)) val))
             (let [arr    (.array nm node)
                   subidx (bit-and (bit-shift-right i shift) (int 0x1f))
-                  child  (.clone nm am shift (aget ^objects arr subidx))]
+                  next-shift (int (unchecked-subtract-int shift (int 5)))
+                  child  (.clone nm am next-shift (aget ^objects arr subidx))]
               (aset ^objects arr subidx child)
-              (recur (unchecked-subtract-int shift (int 5)) child))))
+              (recur next-shift child))))
         node)
       (let [arr    (aclone ^objects (.array nm node))
             rngs   (ranges nm node)

--- a/src/main/clojure/clojure/core/rrb_vector/transients.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/transients.clj
@@ -269,12 +269,13 @@
                 (.aset am arr (bit-and i 0x1f) val))
               (let [arr    (.array nm node)
                     subidx (bit-and (bit-shift-right i shift) 0x1f)
+                    next-shift (int (unchecked-subtract-int shift 5))
                     child  (.ensureEditable this nm am
                                             root-edit
                                             (aget ^objects arr subidx)
-                                            shift)]
+                                            next-shift)]
                 (aset ^objects arr subidx child)
-                (recur (unchecked-subtract-int shift 5) child))))
+                (recur next-shift child))))
           (let [arr    (.array nm ret)
                 rngs   (ranges nm ret)
                 subidx (bit-and (bit-shift-right i shift) 0x1f)


### PR DESCRIPTION
The problem was with code that used a shift value for the wrong level
of the tree when updating nodes during assoc or assoc!  The fix is
specific to the clj implementation, and I believe the bug is, too.
Only the clj implementation has different cases for vectors of all
identical Java primitive types.