### PR TITLE
CRRBV-21 fix, and also some other issues found during testing

### DIFF
--- a/src/main/cljs/clojure/core/rrb_vector/rrbt.cljs
+++ b/src/main/cljs/clojure/core/rrb_vector/rrbt.cljs
@@ -1024,7 +1024,7 @@
 
         :else
         (let [new-tail-base (array-for this cnt shift root tail (- cnt 2))
-              new-tail      (aclone new-tail-base)
+              new-tail      (editable-tail new-tail-base)
               new-tidx      (alength new-tail-base)
               new-root      (pop-tail! shift cnt (.-edit root) root)]
           (cond
@@ -1039,7 +1039,8 @@
                  (nil? (aget (.-arr new-root) 1)))
             (do (set! cnt   (dec cnt))
                 (set! shift (- shift 5))
-                (set! root  (aget (.-arr new-root) 0))
+                (set! root  (ensure-editable (.-edit root)
+                                             (aget (.-arr new-root) 0)))
                 (set! tail  new-tail)
                 (set! tidx  new-tidx)
                 this)

--- a/src/main/cljs/clojure/core/rrb_vector/transients.cljs
+++ b/src/main/cljs/clojure/core/rrb_vector/transients.cljs
@@ -13,7 +13,10 @@
       (VectorNode. edit new-arr))))
 
 (defn editable-root [root]
-  (VectorNode. (js-obj) (aclone (.-arr root))))
+  (let [new-arr (aclone (.-arr root))]
+    (if (== 33 (alength new-arr))
+      (aset new-arr 32 (aclone (aget new-arr 32))))
+    (VectorNode. (js-obj) new-arr)))
 
 (defn editable-tail [tail]
   (let [ret (make-array 32)]
@@ -110,13 +113,8 @@
           (let [arr (.-arr ret)]
             (aset arr subidx nil)
             ret)))
-      (let [subidx (bit-and (bit-shift-right (dec cnt) shift) 0x1f)
-            rngs   (node-ranges ret)
-            subidx (loop [subidx subidx]
-                     (if (or (zero? (int (aget rngs (inc subidx))))
-                             (== subidx 31))
-                       subidx
-                       (recur (inc subidx))))]
+      (let [rngs   (node-ranges ret)
+            subidx (dec (aget rngs 32))]
         (cond
           (> shift 5)
           (let [child     (aget (.-arr ret) subidx)

--- a/src/main/cljs/clojure/core/rrb_vector/trees.cljs
+++ b/src/main/cljs/clojure/core/rrb_vector/trees.cljs
@@ -138,13 +138,8 @@
         (let [arr (aclone (.-arr current-node))]
           (aset arr subidx nil)
           (->VectorNode root-edit arr))))
-    (let [subidx (bit-and (bit-shift-right (dec cnt) shift) 0x1f)
-          rngs   (node-ranges current-node)
-          subidx (loop [subidx subidx]
-                   (if (or (zero? (int (aget rngs (inc subidx))))
-                           (== subidx 31))
-                     subidx
-                     (recur (inc subidx))))
+    (let [rngs   (node-ranges current-node)
+          subidx (dec (aget rngs 32))
           new-rngs (aclone rngs)]
       (cond
         (> shift 5)

--- a/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
+++ b/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
@@ -75,6 +75,30 @@
                       (conj 2001))]
     (is (every? integer? (conj v1129-pre 2002)))))
 
+(deftest test-crrbv-21
+  ;; The following sequence of operations gives a different exception
+  ;; than the above, and I suspect is probably a different root cause
+  ;; with a distinct fix required.  It might be the same root cause as
+  ;; npe-for-1025-then-pop! but I will add a separate test case until
+  ;; I know for sure.  Even if they are the same root cause, it does
+  ;; not take long to run.
+
+  ;; Note: Even once this bug is fixed, I want to know the answer to
+  ;; whether starting from v1128 and then pop'ing off each number of
+  ;; elements, until it is down to empty or very nearly so, causes any
+  ;; of the error checks within the current version of ranges-errors
+  ;; to give an error.  It may require some correcting.
+  (let [v1128 (:marbles (last (play-rrbv 10 1128)))
+        vpop1 (reduce (fn [v i] (pop v))
+                      v1128 (range 1026))]
+    (is (every? integer? (pop vpop1)))
+    ;; The transient version below gives a similar exception, but the
+    ;; call stack goes through the transient version of popTail,
+    ;; rather than the persistent version of popTail that the one
+    ;; above does.  It seems likely that both versions of popTail have
+    ;; a similar bug.
+    (is (every? integer? (persistent! (pop! (transient vpop1)))))))
+
 (deftest test-crrbv-22
   (testing "pop! from a regular transient vector with 32*32+1 elements"
     (let [v1025 (into (fv/vector) (range 1025))]

--- a/src/test/clojure/clojure/core/rrb_vector/test_common.clj
+++ b/src/test/clojure/clojure/core/rrb_vector/test_common.clj
@@ -75,6 +75,30 @@
                       (conj 2001))]
     (is (every? integer? (conj v1129-pre 2002)))))
 
+(deftest test-crrbv-21
+  ;; The following sequence of operations gives a different exception
+  ;; than the above, and I suspect is probably a different root cause
+  ;; with a distinct fix required.  It might be the same root cause as
+  ;; npe-for-1025-then-pop! but I will add a separate test case until
+  ;; I know for sure.  Even if they are the same root cause, it does
+  ;; not take long to run.
+
+  ;; Note: Even once this bug is fixed, I want to know the answer to
+  ;; whether starting from v1128 and then pop'ing off each number of
+  ;; elements, until it is down to empty or very nearly so, causes any
+  ;; of the error checks within the current version of ranges-errors
+  ;; to give an error.  It may require some correcting.
+  (let [v1128 (:marbles (last (play-rrbv 10 1128)))
+        vpop1 (reduce (fn [v i] (pop v))
+                      v1128 (range 1026))]
+    (is (every? integer? (pop vpop1)))
+    ;; The transient version below gives a similar exception, but the
+    ;; call stack goes through the transient version of popTail,
+    ;; rather than the persistent version of popTail that the one
+    ;; above does.  It seems likely that both versions of popTail have
+    ;; a similar bug.
+    (is (every? integer? (persistent! (pop! (transient vpop1)))))))
+
 (deftest test-crrbv-22
   (testing "pop! from a regular transient vector with 32*32+1 elements"
     (let [v1025 (into (fv/vector) (range 1025))]


### PR DESCRIPTION
Notes on clj code changes:

The changes to binding the value of subidx in both popTail methods,
persistent and transient, are because I believe that popTail should
simply be always going for the last child every time, and when a node
is non-regular, the index of that last child is always simply (dec
(aget rngs 32)).  There is no need to use any kind of a loop to find
out what it is.  The existing loop code for calculating subidx usually
ends up with the value (dec (aget rngs 32)), but with some vectors
with non-regular nodes, it calculates something else.

This change in rrbt.clj below is in deftype Transient's pop method.
The change ensures that the new tail is an array of 32 elements.  RRB
vectors with non-regular nodes can have arrays of vector elements
shorter than 32 elements, and without this change, pop! operations can
cause those short arrays to be copied with length less than 32 to the
tail.  Transient's conj method assumes the tail is 32 elements long,
and without the change below, pop leaves the tail in a state where
conj can throw an exception.

-            new-tail      (.aclone am new-tail-base)
+            new-tail      (.editableTail transient-helper am new-tail-base)

The change in rrbt.clj below is in deftype Transient's pop method.
The change ensures that when the tree gets 1 level shallower, that the
new root node has the correct value of its 'edit' field.  Without this
change, the new root might have an 'edit' field equal to nil, or an
AtomicReference containing nil, rather than the correct value, which
is an object reference identical to the former root's edit field
reference, which is to an AtomicReference containing a reference to
the Thread that created the transient vector.

-              (set! root  (aget ^objects (.array nm new-root) 0))
+              (set! root  (.ensureEditable
+                           transient-helper nm am
+                           (.edit nm root)
+                           (aget ^objects (.array nm new-root) 0)
+                           (unchecked-subtract-int shift (int 5))))

The change below in the transient-helper's editableRoot method makes
it more similar to the ensureEditable method (the one with more
parameters).  Whenever an array of children is cloned, if it has an
array of ranges, that must be cloned as well.  Without this change, it
is possible for operations on a transient vector to mutate the
persistent vector it was created from, which I saw during REPL testing
of the other changes.

-      (.node nm
-             (AtomicReference. (Thread/currentThread))
-             (clojure.core/aclone ^objects (.array nm root))))
+      (let [new-arr (clojure.core/aclone ^objects (.array nm root))]
+        (if (== 33 (alength ^objects new-arr))
+          (aset new-arr 32 (aclone (ints (aget ^objects new-arr 32)))))
+        (.node nm (AtomicReference. (Thread/currentThread)) new-arr)))

The change below is in transient-helper's popTail method.  The code
before the change looks like an obvious typo.  It makes no sense to
subtract 5 from subidx in a recursive call to popTail that for all
other similar recursive calls uses (- shift 5).  I do not have a test
case that causes the old code to fail -- this was caught by accident
when reading the code.

-                                        (unchecked-subtract-int subidx 5)
+                                        (unchecked-subtract-int shift 5)

Notes on cljs code changes:

The changes for cljs are nearly identical to those for clj.

The changes to binding the value of subidx in both popTail methods,
persistent and transient, are because I believe that popTail should
simply be always going for the last child every time, and when a node
is non-regular, the index of that last child is always simply (dec
(aget rngs 32)).  There is no need to use any kind of a loop to find
out what it is.  The existing loop code for calculating subidx usually
ends up with the value (dec (aget rngs 32)), but with some vectors
with non-regular nodes, it calculates something else.

This change in rrbt.cljs below is in deftype Transient's pop method.
The change ensures that the new tail is an array of 32 elements.  RRB
vectors with non-regular nodes can have arrays of vector elements
shorter than 32 elements, and without this change, pop! operations can
cause those short arrays to be copied with length less than 32 to the
tail.  Transient's conj method assumes the tail is 32 elements long,
and without the change below, pop leaves the tail in a state where
conj can throw an exception.

-              new-tail      (aclone new-tail-base)
+              new-tail      (editable-tail new-tail-base)

The change in rrbt.cljs below is in deftype Transient's pop method.
The change ensures that when the tree gets 1 level shallower, that the
new root node has the correct value of its 'edit' field.  Without this
change, the new root might have an 'edit' field equal to nil, or a
(js-object) return value from an earlier transient editing of a tree
containing the node at that time.  This is rather than the correct
value, which is an object reference identical to the former root's
edit field reference, which is a unique object returned by (js-object)
just for this transient.

-                (set! root  (aget (.-arr new-root) 0))
+                (set! root  (ensure-editable (.-edit root)
+                                             (aget (.-arr new-root) 0)))

The change below in the editable-root function makes it more similar
to the function ensure-editable.  Whenever an array of children is
cloned, if it has an array of ranges, that must be cloned as well.
Without this change, it is possible for operations on a transient
vector to mutate the persistent vector it was created from, which I
saw during REPL testing of the other changes.

 (defn editable-root [root]
-  (VectorNode. (js-obj) (aclone (.-arr root))))
+  (let [new-arr (aclone (.-arr root))]
+    (if (== 33 (alength new-arr))
+      (aset new-arr 32 (aclone (aget new-arr 32))))
+    (VectorNode. (js-obj) new-arr)))