### PR TITLE
Fix several small things

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,8 @@ To run Clojure tests, but no ClojureScript tests:
 ```bash
 $ lein with-profile +1.10 test
 ```
-You can test with Clojure versions 1.6 through 1.10 by specifying that
-version number after the `+`.  You can test with Clojure 1.5.1 using
-`lein test`.
+You can test with Clojure versions 1.5 through 1.10 by specifying that
+version number after the `+`.
 
 To run ClojureScript tests with Node.js and Spidermonkey JavaScript
 runtimes, but no Clojure tests:

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject org.clojure/core.rrb-vector "0.0.12-SNAPSHOT"
+(defproject org.clojure/core.rrb-vector "0.0.15-SNAPSHOT"
   :description "RRB-Trees for Clojure(Script) -- see Bagwell & Rompf"
   :url "https://github.com/clojure/core.rrb-vector"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.2.0"
-  :parent [org.clojure/pom.contrib "0.1.2"]
+  :parent [org.clojure/pom.contrib "0.2.2"]
   :dependencies [[org.clojure/clojure "1.5.1"]]
   :source-paths ["src/main/clojure"
                  "src/main/cljs"]
@@ -19,6 +19,7 @@
                    :plugins [[lein-cljsbuild "1.1.7"]]}
              :cljs {:dependencies [[org.clojure/clojure "1.10.0"]
                                    [org.clojure/clojurescript "1.10.238"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
@@ -865,7 +865,7 @@
                                " object array to become a node, when that"
                                " index should only be used for storing"
                                " range arrays.")
-                      data {:shift shift, :cnd cnt, :node node,
+                      data {:shift shift, :cnt cnt, :node node,
                             :tail-node tail-node, :rngs rngs, :li li,
                             :cret cret}]
                   (throw (ex-info msg data))))

--- a/src/test/cljs/clojure/core/rrb_vector/test_cljs_basic.cljs
+++ b/src/test/cljs/clojure/core/rrb_vector/test_cljs_basic.cljs
@@ -26,8 +26,13 @@
   (is (dv/check-catvec 10 40 40 40 40 40 40 40 40))
   (is (apply dv/check-catvec (repeat 30 33))))
 
+(def medium-check-catvec-params [250 30 10 60000])
+(def short-check-catvec-params [10 30 10 60000])
+;;(def check-catvec-params medium-check-catvec-params)
+(def check-catvec-params short-check-catvec-params)
+
 (deftest test-splicing-generative
-  (try (dv/generative-check-catvec 125 15 10 30000)
+  (try (apply dv/generative-check-catvec check-catvec-params)
        (catch ExceptionInfo e
          (throw (ex-info (format "%s: %s"
                                  (.getMessage e)


### PR DESCRIPTION
Although the Leiningen project.clj file is only a developer aid, and
pom.xml is the official source for all things about the project, try
to keep the version number in project.clj up to date with what is in
pom.xml, in case a core.rrb-vector developer wants to run 'lein
install'.

Fix a typo in a keyword of an ex-info error map.  Not a bug, but an
annoying inconsistency of names.

Reduce the run-time duration of the slowest cljs deftest, which is a
generative test.  This should help keep the typical pre-commit test
times on a developer's machine more reasonable, as well as reduce them
on build.clojure.org.  Developers are free to ramp up the durations of
these tests on their local development machines if they wish, of
course.