### PR TITLE
CRRBV-14: Add peephole optimizer for results of catvec

### DIFF
--- a/src/main/cljs/clojure/core/rrb_vector/rrbt.cljs
+++ b/src/main/cljs/clojure/core/rrb_vector/rrbt.cljs
@@ -13,7 +13,8 @@
                      do-assoc]]
             [clojure.core.rrb-vector.transients
              :refer [ensure-editable editable-root editable-tail push-tail!
-                     pop-tail! do-assoc!]]))
+                     pop-tail! do-assoc!]])
+  (:require-macros [clojure.core.rrb-vector.macros :refer [dbg]]))
 
 (def ^:const rrbt-concat-threshold 33)
 (def ^:const max-extra-search-steps 2)
@@ -859,9 +860,230 @@
             (aset new-rngs 32 i)))
         (array (->VectorNode nil new-arr) nil)))))
 
+(def peephole-optimization-config (atom {:debug-fn nil}))
+(def peephole-optimization-count (atom 0))
+
+;; TBD: Transducer versions of child-nodes and bounded-grandchildren
+;; are included here for when we are willing to rely upon Clojure
+;; 1.7.0 as the minimum version supported by the core.rrb-vector
+;; library.  They are faster.
+
+#_(defn child-nodes [node]
+  (into [] (comp (take-while (complement nil?))
+                 (take 32))
+        (.-arr node)))
+
+(defn child-nodes [node]
+  (->> (.-arr node)
+       (take-while (complement nil?))
+       (take 32)))
+
+;; (take 33) is just a technique to avoid generating more
+;; grandchildren than necessary.  If there are at least 33, we do not
+;; care how many there are.
+#_(defn bounded-grandchildren [children]
+  (into [] (comp (map child-nodes)
+                 cat
+                 (take 33))
+        children))
+
+(defn bounded-grandchildren [children]
+  (->> children
+       (mapcat child-nodes)
+       (take 33)))
+
+;; TBD: Do functions like last-non-nil-idx and
+;; count-vector-elements-beneath already exist elsewhere in this
+;; library?  It seems like they might.
+
+;; A regular tree node is guaranteed to have only 32-way branching at
+;; all nodes, except perhaps along the right spine, where it can be
+;; partial.  From a regular tree node down, all leaf arrays
+;; (containing vector elements directly) are restricted to contain a
+;; full 32 vector elements.  This code relies on these invariants to
+;; quickly calculate the number of vector elements beneath a regular
+;; node in O(log N) time.
+
+(defn last-non-nil-idx [arr]
+  (loop [i (dec (alength arr))]
+    (if (neg? i)
+      i
+      (if (nil? (aget arr i))
+        (recur (dec i))
+        i))))
+
+(defn count-vector-elements-beneath [node shift]
+  (if (regular? node)
+    (loop [node node
+           shift shift
+           acc 0]
+      (if (zero? shift)
+        (if (nil? node)
+          acc
+          ;; The +32 is for the regular leaf node reached at shift 0
+          (+ acc 32))
+        (let [arr (.-arr node)
+              max-child-idx (last-non-nil-idx arr)
+              num-elems-in-full-child (bit-shift-left 1 shift)]
+          (if (< max-child-idx 0)
+            acc
+            (recur (aget arr max-child-idx)
+                   (- shift 5)
+                   (+ acc (* max-child-idx num-elems-in-full-child)))))))
+    ;; irregular case
+    (let [rngs (node-ranges node)]
+      (aget rngs (dec (aget rngs 32))))))
+
+(defn peephole-optimize-root [v]
+  (let [config @peephole-optimization-config]
+    (if (<= (.-shift v) 10)
+      ;; Tree depth cannot be reduced if shift <= 5.
+      ;; TBD: If shift=10, the grandchildren nodes need to be handled
+      ;; by an am array manager for primitive vectors, which I haven't
+      ;; written code for yet below, but so far this peephole
+      ;; optimizer seems to be working sufficiently well without
+      ;; handling that case.
+      v
+      (let [root (.-root v)
+            children (child-nodes root)
+            ;; (take 33) is just a technique to avoid generating more
+            ;; grandchildren than necessary.  If there are at least
+            ;; 33, we do not care how many there are.
+            grandchildren (into [] (comp (map child-nodes)
+                                         cat
+                                         (take 33))
+                                children)
+            num-granchildren-bounded (count grandchildren)
+            many-grandchildren? (> num-granchildren-bounded 32)]
+        (if many-grandchildren?
+          ;; If it is possible to reduce tree depth, it requires going
+          ;; deeper than just to the grandchildren, which is beyond
+          ;; what this peephole optimizer is intended to do.
+          v
+          ;; Create a new root node that points directly at the
+          ;; grandchildren, since there are few enough of them.
+          (let [new-arr  (make-array 33)
+                new-rngs (make-array 33)
+                new-root (->VectorNode (.-edit root) new-arr)
+                shift    (.-shift v)
+                grandchild-shift (- shift (* 2 5))]
+            (swap! peephole-optimization-count inc)
+            (loop [idx 0
+                   remaining-gc grandchildren
+                   elem-sum 0]
+              (if-let [remaining-gc (seq remaining-gc)]
+                (let [grandchild (first remaining-gc)
+                      num-elems-this-grandchild (count-vector-elements-beneath
+                                                 grandchild grandchild-shift)
+                      next-elem-sum (+ elem-sum num-elems-this-grandchild)]
+                  (aset new-arr idx grandchild)
+                  (aset new-rngs idx next-elem-sum)
+                  (recur (inc idx) (rest remaining-gc) next-elem-sum))))
+            (aset new-rngs 32 num-granchildren-bounded)
+            (aset new-arr 32 new-rngs)
+            (let [new-v (Vector. (.-cnt v) (- shift 5)
+                                 new-root (.-tail v) (.-meta v) nil)]
+              (when (:debug-fn config)
+                ((:debug-fn config) v new-v))
+              new-v)))))))
+
+;; TBD: I do not know if this implementation actually supports this
+;; many elements in one vector.  What is the limit?  I picked this
+;; number simply to match what I believe is the upper limit for the
+;; Clojure implementation.
+(def max-vector-elements 2147483647)
+
+;; Larger shift values than 64 definitely break assumptions all over
+;; the RRB vector implementation, e.g. (bit-shift-right 255 65)
+;; returns the same result as (bit-shift-right 255 1), I believe
+;; because the shift amount argument is effectively modulo'd by 64.
+;; Larger shift values than 30 are unlikely to make sense, given that
+;; the maximum number of vector elements supported is somewhere near
+;; 2^31-1.
+
+(defn shift-too-large? [v]
+  (> (.-shift v) 30))
+
+;; The maximum number of vector elements in a tree, not counting any
+;; elements in the tail, with a given shift value is:
+;;
+;; (bit-shift-left 1 (+ shift 5))
+;;
+;; It is perfectly normal to have vectors with a root tree node with
+;; only 1 non-nil child, so at a fraction 1/32 of maximum capacity.  I
+;; do not know the exact minimum fraction that RRB vectors as
+;; implemented here should allow, but I suspect it is well over
+;; 1/1024.
+
+(defn poor-branching? [v]
+  (let [tail-off (tail-offset v)]
+    (if (zero? tail-off)
+      false
+      (let [shift-amount (- (.-shift v) 5)
+            max-capacity-over-1024 (bit-shift-left 1 shift-amount)]
+        (< tail-off max-capacity-over-1024)))))
+
+;; Note 3:
+
+;; Consider measuring several ways in ClojureScript to create a
+;; regular persistent vector from another one, to see which is
+;; fastest, and use it here.
+
+;; TBD: Is there any promise about what metadata catvec returns?
+;; Always the same as on the first argument?
+
+(def fallback-config (atom {:debug-fn nil}))
+(def fallback-to-slow-splice-count1 (atom 0))
+(def fallback-to-slow-splice-count2 (atom 0))
+
+(defn fallback-to-slow-splice-if-needed [v1 v2 splice-result]
+  (let [config @fallback-config]
+    (if (or (shift-too-large? splice-result)
+            (poor-branching? splice-result))
+      (do
+        (dbg (str "splice-rrbts result had shift " (.-shift splice-result)
+                  " and " (tail-offset splice-result) " elements not counting"
+                  " the tail. Falling back to slower method of concatenation."))
+        (if (poor-branching? v1)
+          ;; The v1 we started with was not good, either.
+          (do
+            (swap! fallback-to-slow-splice-count1 inc)
+            (dbg (str "splice-rrbts first arg had shift " (.-shift v1)
+                      " and " (tail-offset v1) " elements not counting"
+                      " the tail.  Building the result from scratch."))
+            ;: See Note 3
+            (let [new-splice-result (-> (empty v1) (into v1) (into v2))]
+              (when (:debug-fn config)
+                ((:debug-fn config) splice-result new-splice-result))
+              new-splice-result))
+          ;; Assume that v1 is balanced enough that we can use into to
+          ;; add all elements of v2 to it, without problems.  TBD:
+          ;; That assumption might be incorrect.  Consider checking
+          ;; the result of this, too, and fall back again to the true
+          ;; case above?
+          (let [new-splice-result (into v1 v2)]
+            (swap! fallback-to-slow-splice-count2 inc)
+            (when (:debug-fn config)
+              ((:debug-fn config) splice-result new-splice-result))
+            new-splice-result)))
+      ;; else the fast result is good
+      splice-result)))
+
+(defn post-splice-fixup [v1 v2 splice-result]
+  (->> splice-result
+       peephole-optimize-root
+       (fallback-to-slow-splice-if-needed v1 v2)))
+
 (defn splice-rrbts [v1 v2]
   (cond
     (zero? (count v1)) v2
+    (> (+ (count v1) (count v2)) max-vector-elements)
+    (let [c1 (count v1), c2 (count v2)]
+      (throw (js/Error.
+              (str "Attempted to concatenate two vectors whose total"
+                   " number of elements is " (+ c1 c2) ", which is"
+                   " larger than the maximum number of elements "
+                   max-vector-elements " supported in a vector "))))
     (< (count v2) rrbt-concat-threshold) (into v1 v2)
     :else
     (let [s1 (.-shift v1)
@@ -907,24 +1129,26 @@
           ncnt2   (if n2
                     ncnt2
                     0)]
-      (if n2
-        (let [arr      (make-array 33)
-              new-root (->VectorNode nil arr)]
-          (aset arr 0 n1)
-          (aset arr 1 n2)
-          (aset arr 32 (doto (make-array 33)
-                         (aset 0 ncnt1)
-                         (aset 1 (+ ncnt1 ncnt2))
-                         (aset 32 2)))
-          (Vector. (+ (count v1) (count v2)) (+ s 5) new-root (.-tail v2)
-                   nil nil))
-        (loop [r n1
-               s s]
-          (if (and (> s 5)
-                   (nil? (aget (.-arr r) 1)))
-            (recur (aget (.-arr r) 0) (- s 5))
-            (Vector. (+ (count v1) (count v2)) s r (.-tail v2)
-                     nil nil)))))))
+      (post-splice-fixup
+       v1 v2
+       (if n2
+         (let [arr      (make-array 33)
+               new-root (->VectorNode nil arr)]
+           (aset arr 0 n1)
+           (aset arr 1 n2)
+           (aset arr 32 (doto (make-array 33)
+                          (aset 0 ncnt1)
+                          (aset 1 (+ ncnt1 ncnt2))
+                          (aset 32 2)))
+           (Vector. (+ (count v1) (count v2)) (+ s 5) new-root (.-tail v2)
+                    nil nil))
+         (loop [r n1
+                s s]
+           (if (and (> s 5)
+                    (nil? (aget (.-arr r) 1)))
+             (recur (aget (.-arr r) 0) (- s 5))
+             (Vector. (+ (count v1) (count v2)) s r (.-tail v2)
+                      nil nil))))))))
 
 (deftype Transient [^:mutable cnt
                     ^:mutable shift

--- a/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
@@ -1541,9 +1541,232 @@
             (aset new-rngs 32 i)))
         (pair (.node nm nil new-arr) nil)))))
 
+(def peephole-optimization-config (atom {:debug-fn nil}))
+(def peephole-optimization-count (atom 0))
+
+;; TBD: Transducer versions of child-nodes and bounded-grandchildren
+;; are included here for when we are willing to rely upon Clojure
+;; 1.7.0 as the minimum version supported by the core.rrb-vector
+;; library.  They are faster.
+
+#_(defn child-nodes [node ^NodeManager nm]
+  (into [] (comp (take-while (complement nil?))
+                 (take 32))
+        (.array nm node)))
+
+(defn child-nodes [node ^NodeManager nm]
+  (->> (.array nm node)
+       (take-while (complement nil?))
+       (take 32)))
+
+;; (take 33) is just a technique to avoid generating more
+;; grandchildren than necessary.  If there are at least 33, we do not
+;; care how many there are.
+#_(defn bounded-grandchildren [nm children]
+  (into [] (comp (map #(child-nodes % nm))
+                 cat
+                 (take 33))
+        children))
+
+(defn bounded-grandchildren [nm children]
+  (->> children
+       (mapcat #(child-nodes % nm))
+       (take 33)))
+
+;; TBD: Do functions like last-non-nil-idx and
+;; count-vector-elements-beneath already exist elsewhere in this
+;; library?  It seems like they might.
+
+;; A regular tree node is guaranteed to have only 32-way branching at
+;; all nodes, except perhaps along the right spine, where it can be
+;; partial.  From a regular tree node down, all leaf arrays
+;; (containing vector elements directly) are restricted to contain a
+;; full 32 vector elements.  This code relies on these invariants to
+;; quickly calculate the number of vector elements beneath a regular
+;; node in O(log N) time.
+
+(defn last-non-nil-idx [^objects arr]
+  (loop [i (int (dec (alength arr)))]
+    (if (neg? i)
+      i
+      (if (nil? (aget arr (int i)))
+        (recur (unchecked-dec-int i))
+        i))))
+
+(defn count-vector-elements-beneath [node shift ^NodeManager nm]
+  (if (.regular nm node)
+    (loop [node node
+           shift shift
+           acc 0]
+      (if (zero? shift)
+        (if (nil? node)
+          acc
+          ;; The +32 is for the regular leaf node reached at shift 0
+          (+ acc 32))
+        (let [^objects arr (.array nm node)
+              max-child-idx (int (last-non-nil-idx arr))
+              num-elems-in-full-child (int (bit-shift-left 1 shift))]
+          (if (< max-child-idx 0)
+            acc
+            (recur (aget ^objects arr max-child-idx)
+                   (unchecked-subtract-int shift (int 5))
+                   (unchecked-add-int acc (unchecked-multiply-int
+                                           max-child-idx
+                                           num-elems-in-full-child)))))))
+    ;; irregular case
+    (let [rngs (ranges nm node)]
+      (aget rngs (dec (aget rngs 32))))))
+
+(defn peephole-optimize-root [^Vector v]
+  (let [config @peephole-optimization-config]
+    (if (<= (.-shift v) 10)
+      ;; Tree depth cannot be reduced if shift <= 5.
+      ;; TBD: If shift=10, the grandchildren nodes need to be handled
+      ;; by an am array manager for primitive vectors, which I haven't
+      ;; written code for yet below, but so far this peephole
+      ;; optimizer seems to be working sufficiently well without
+      ;; handling that case.
+      v
+      (let [root (.-root v)
+            ^NodeManager nm (.-nm v)
+            children (child-nodes root nm)
+            grandchildren (bounded-grandchildren nm children)
+            num-granchildren-bounded (count grandchildren)
+            many-grandchildren? (> num-granchildren-bounded 32)]
+        (if many-grandchildren?
+          ;; If it is possible to reduce tree depth, it requires going
+          ;; deeper than just to the grandchildren, which is beyond
+          ;; what this peephole optimizer is intended to do.
+          v
+          ;; Create a new root node that points directly at the
+          ;; grandchildren, since there are few enough of them.
+          (let [^objects new-arr  (object-array 33)
+                ^ints new-rngs (int-array 33)
+                new-root (.node nm (.edit nm root) new-arr)
+                shift    (.-shift v)
+                grandchild-shift (- shift (* 2 5))]
+            (swap! peephole-optimization-count inc)
+            (loop [idx 0
+                   remaining-gc grandchildren
+                   elem-sum (int 0)]
+              (if-let [remaining-gc (seq remaining-gc)]
+                (let [grandchild (first remaining-gc)
+                      num-elems-this-grandchild (count-vector-elements-beneath
+                                                 grandchild grandchild-shift nm)
+                      next-elem-sum (int (+ elem-sum num-elems-this-grandchild))]
+                  (aset new-arr idx grandchild)
+                  (aset new-rngs idx next-elem-sum)
+                  (recur (inc idx) (rest remaining-gc) next-elem-sum))))
+            (aset new-rngs 32 num-granchildren-bounded)
+            (aset new-arr 32 new-rngs)
+            (let [new-v (Vector. nm (.-am v) (.-cnt v) (- shift 5)
+                                 new-root (.-tail v) (.-_meta v) -1 -1)]
+              (when (:debug-fn config)
+                ((:debug-fn config) v new-v))
+              new-v)))))))
+
+(def max-vector-elements Integer/MAX_VALUE)
+
+;; Larger shift values than 64 definitely break assumptions all over
+;; the RRB vector implementation, e.g. (bit-shift-right 255 65)
+;; returns the same result as (bit-shift-right 255 1), I believe
+;; because the shift amount argument is effectively modulo'd by 64.
+;; Larger shift values than 30 are unlikely to make sense, given that
+;; the maximum number of vector elements supported is somewhere near
+;; Integer/MAX_VALUE=2^31-1.
+
+(defn shift-too-large? [^Vector v]
+  (> (.-shift v) 30))
+
+;; The maximum number of vector elements in a tree, not counting any
+;; elements in the tail, with a given shift value is:
+;;
+;; (bit-shift-left 1 (+ shift 5))
+;;
+;; It is perfectly normal to have vectors with a root tree node with
+;; only 1 non-nil child, so at a fraction 1/32 of maximum capacity.  I
+;; do not know the exact minimum fraction that RRB vectors as
+;; implemented here should allow, but I suspect it is well over
+;; 1/1024.
+
+(defn poor-branching? [^Vector v]
+  (let [tail-off (.tailoff v)]
+    (if (zero? tail-off)
+      false
+      (let [shift-amount (unchecked-subtract-int (.-shift v) (int 5))
+            max-capacity-over-1024 (bit-shift-left 1 shift-amount)]
+        (< tail-off max-capacity-over-1024)))))
+
+;; Note 3:
+
+;; Consider checking the performance of an expression like the one
+;; used now against the one below:
+
+;;(into (clojure.lang.LazilyPersistentVector/create v1) v2))
+
+;; If the LazilyPersistentVector/create version is faster, it would be
+;; good to create a version of the create method that returns
+;; primitive vectors when given a primitive vector, and an Object
+;; vector when given an Object vector.  The existing method in Clojure
+;; core always returns an Object vector, even when given a primitive
+;; vector.
+
+;; TBD: Is there any promise about what metadata catvec returns?
+;; Always the same as on the first argument?
+
+(def fallback-config (atom {:debug-fn nil}))
+(def fallback-to-slow-splice-count1 (atom 0))
+(def fallback-to-slow-splice-count2 (atom 0))
+
+(defn fallback-to-slow-splice-if-needed [^Vector v1 ^Vector v2
+                                         ^Vector splice-result]
+  (let [config @fallback-config]
+    (if (or (shift-too-large? splice-result)
+            (poor-branching? splice-result))
+      (do
+        (dbg (str "splice-rrbts result had shift " (.-shift splice-result)
+                  " and " (.tailoff splice-result) " elements not counting"
+                  " the tail. Falling back to slower method of concatenation."))
+        (if (poor-branching? v1)
+          ;; The v1 we started with was not good, either.
+          (do
+            (swap! fallback-to-slow-splice-count1 inc)
+            (dbg (str "splice-rrbts first arg had shift " (.-shift v1)
+                      " and " (.tailoff v1) " elements not counting"
+                      " the tail.  Building the result from scratch."))
+            ;: See Note 3
+            (let [new-splice-result (-> (empty v1) (into v1) (into v2))]
+              (when (:debug-fn config)
+                ((:debug-fn config) splice-result new-splice-result))
+              new-splice-result))
+          ;; Assume that v1 is balanced enough that we can use into to
+          ;; add all elements of v2 to it, without problems.
+          ;; TBD: That assumption might be incorrect.  Consider
+          ;; checking the result of this, too, and fall back again to
+          ;; the true case above?
+          (let [new-splice-result (into v1 v2)]
+            (swap! fallback-to-slow-splice-count2 inc)
+            (when (:debug-fn config)
+              ((:debug-fn config) splice-result new-splice-result))
+            new-splice-result)))
+      ;; else the fast result is good
+      splice-result)))
+
+(defn post-splice-fixup [^Vector v1 ^Vector v2 ^Vector splice-result]
+  (->> splice-result
+       peephole-optimize-root
+       (fallback-to-slow-splice-if-needed v1 v2)))
+
 (defn splice-rrbts [^NodeManager nm ^ArrayManager am ^Vector v1 ^Vector v2]
   (cond
     (zero? (count v1)) v2
+    (> (+ (long (count v1)) (long (count v2))) max-vector-elements)
+    (let [c1 (long (count v1)), c2 (long (count v2))]
+      (throw (IllegalArgumentException.
+              (str "Attempted to concatenate two vectors whose total"
+                   " number of elements is " (+ c1 c2) ", which is"
+                   " larger than the maximum number of elements "
+                   max-vector-elements " supported in a vector "))))
     (< (count v2) rrbt-concat-threshold) (into v1 v2)
     :else
     (let [s1 (.-shift v1)
@@ -1588,25 +1811,27 @@
           ncnt2   (if n2
                     (int ncnt2)
                     (int 0))]
-      (if n2
-        (let [arr      (object-array 33)
-              new-root (.node nm nil arr)]
-          (aset arr 0 n1)
-          (aset arr 1 n2)
-          (aset arr 32 (doto (int-array 33)
-                         (aset 0 ncnt1)
-                         (aset 1 (+ ncnt1 ncnt2))
-                         (aset 32 2)))
-          (Vector. nm am (+ (count v1) (count v2)) (+ s 5) new-root (.-tail v2)
-                   nil -1 -1))
-        (loop [r n1
-               s (int s)]
-          (if (and (> s (int 5))
-                   (nil? (aget ^objects (.array nm r) 1)))
-            (recur (aget ^objects (.array nm r) 0)
-                   (unchecked-subtract-int s (int 5)))
-            (Vector. nm am (+ (count v1) (count v2)) s r (.-tail v2)
-                     nil -1 -1)))))))
+      (post-splice-fixup
+       v1 v2
+       (if n2
+         (let [arr      (object-array 33)
+               new-root (.node nm nil arr)]
+           (aset arr 0 n1)
+           (aset arr 1 n2)
+           (aset arr 32 (doto (int-array 33)
+                          (aset 0 ncnt1)
+                          (aset 1 (+ ncnt1 ncnt2))
+                          (aset 32 2)))
+           (Vector. nm am (+ (count v1) (count v2)) (+ s 5) new-root (.-tail v2)
+                    nil -1 -1))
+         (loop [r n1
+                s (int s)]
+           (if (and (> s (int 5))
+                    (nil? (aget ^objects (.array nm r) 1)))
+             (recur (aget ^objects (.array nm r) 0)
+                    (unchecked-subtract-int s (int 5)))
+             (Vector. nm am (+ (count v1) (count v2)) s r (.-tail v2)
+                      nil -1 -1))))))))
 
 (defn array-copy [^ArrayManager am from i to j len]
   (loop [i   (int i)

--- a/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
+++ b/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
@@ -1,6 +1,7 @@
 (ns clojure.core.rrb-vector.test-common
   (:require [clojure.test :as test :refer [deftest testing is]]
-            [clojure.core.rrb-vector :as fv]))
+            [clojure.core.rrb-vector :as fv]
+            [clojure.core.rrb-vector.rrbt :as rrbt]))
 
 ;; The intent is to keep this file as close to
 ;; src/test/clojure/clojure/core/rrb_vector/test_common.clj as
@@ -108,3 +109,94 @@
     (let [v1025 (into (fv/vector) (range 1025))]
       (is (= (pop v1025)
              (range 1024))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; This code was copied from
+;; https://github.com/mattiasw2/adventofcode1/blob/master/src/adventofcode1/nineteen_b.clj
+
+;; mentioned in issue
+;; https://clojure.atlassian.net/projects/CRRBV/issues/CRRBV-14
+
+(defn puzzle-b [n my-vec my-catvec my-subvec]
+  (letfn [(remove-at [arr idx]
+            (my-catvec (my-subvec arr 0 idx) (my-subvec arr (inc idx))))
+          (create-arr [size]
+            (my-vec (range 1 (inc size))))
+          (fv-rest [arr]
+            (my-subvec arr 1))
+          (calculate-opposite [n]
+            (int (/ n 2)))
+          (move [elfs]
+            (let [lc (count elfs)]
+              (if (= 1 lc)
+                {:ok (first elfs)}
+                (let [current      (first elfs)
+                      opposite-pos (calculate-opposite lc)
+                      _ (assert (> opposite-pos 0))
+                      _ (assert (< opposite-pos lc))
+                      opposite-elf (nth elfs opposite-pos)
+                      other2       (fv-rest (remove-at elfs opposite-pos))]
+                  (my-catvec other2 [current])))))
+          (puzzle-b-sample [elfs round]
+            (let [elfs2 (move elfs)]
+              (if (:ok elfs2)
+                (:ok elfs2)
+                (recur elfs2 (inc round)))))]
+    (puzzle-b-sample (create-arr n) 1)))
+
+(defn puzzle-b-core [n]
+  (puzzle-b n clojure.core/vec clojure.core/into clojure.core/subvec))
+
+(defn get-shift [v]
+  (.-shift v))
+
+(defn vstats [v]
+  (str "cnt=" (count v)
+       " shift=" (get-shift v)
+       ;;" %=" (format "%5.1f" (* 100.0 (dv/fraction-full v)))
+       ))
+
+;;(def custom-catvec-data (atom []))
+
+(defn custom-catvec [& args]
+  (let [;;n (count @custom-catvec-data)
+        max-arg-shift (apply max (map get-shift args))
+        ret (apply fv/catvec args)
+        ret-shift (get-shift ret)]
+    (when (or (>= ret-shift 30)
+              (> ret-shift max-arg-shift))
+      (doall (map-indexed
+              (fn [idx v]
+                (println (str "custom-catvec ENTER v" idx "  " (vstats v))))
+              args))
+      (println (str "custom-catvec LEAVE ret " (vstats ret))))
+    ;;(swap! custom-catvec-data conj {:args args :ret ret})
+    ;;(println "custom-catvec RECRD in index" n "of @custom-catvec-data")
+    ret))
+
+(defn puzzle-b-rrbv [n]
+  (puzzle-b n fv/vec custom-catvec fv/subvec))
+
+(defn reset-optimizer-counts! []
+  (println "reset all optimizer counts to 0")
+  (reset! rrbt/peephole-optimization-count 0)
+  (reset! rrbt/fallback-to-slow-splice-count1 0)
+  (reset! rrbt/fallback-to-slow-splice-count2 0))
+
+(defn print-optimizer-counts []
+  (println "optimizer counts: peephole=" @rrbt/peephole-optimization-count
+           "fallback1=" @rrbt/fallback-to-slow-splice-count1
+           "fallback2=" @rrbt/fallback-to-slow-splice-count2))
+
+(deftest test-crrbv-14
+  ;; This one passes
+  (reset-optimizer-counts!)
+  (is (= (puzzle-b-core 977)
+         (puzzle-b-rrbv 977)))
+  (print-optimizer-counts)
+  ;; (puzzle-b-rrbv 978) throws
+  ;; ArrayIndexOutOfBoundsException
+  (reset-optimizer-counts!)
+  (is (integer? (puzzle-b-rrbv 978)))
+  (print-optimizer-counts))


### PR DESCRIPTION
There is likely a cleaner improvement to the splice-rrbt function that
will give a result as good as this does, but this code basically just
does the normal splice-rrbt as part of the catvec implementation,
followed by a peephole optimizer that in some cases reduces the top 3
levels of the tree down to 2.

There is no known proof that this prevents the former problems of the
tree depth growing without bound when many catvec operations of
certain kinds are done, but in pretty extensive testing, no cases have
yet been found where the tree depth grows as it did before.