### PR TITLE
CRRBV-25: return same hash for empty RRB vector as for normal empty v…

### DIFF
--- a/src/main/cljs/clojure/core/rrb_vector/macros.clj
+++ b/src/main/cljs/clojure/core/rrb_vector/macros.clj
@@ -21,5 +21,4 @@
                         `(cljs.core/aset ~arr ~i ~param))
                       params)
        (clojure.core.rrb_vector.rrbt.Vector.
-        ~(count params) 5 cljs.core.PersistentVector.EMPTY_NODE ~arr nil
-        ~(if params nil 0)))))
+        ~(count params) 5 cljs.core.PersistentVector.EMPTY_NODE ~arr nil nil))))

--- a/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
+++ b/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
@@ -9,6 +9,19 @@
 ;; for this library, this file and that one can be replaced with a
 ;; common test file with the suffix .cljc
 
+(deftest test-hasheq
+  (is (= (hash []) (hash (fv/vector))))  ;; CRRBV-25
+  (let [v1 (vec (range 1024))
+        v2 (vec (range 1024))
+        v3 (fv/catvec (vec (range 512)) (vec (range 512 1024)))
+        s1 (seq v1)
+        s2 (seq v2)
+        s3 (seq v3)]
+    (is (= (hash v1) (hash v2) (hash v3) (hash s1) (hash s2) (hash s3)))
+    (is (= (hash (nthnext s1 120))
+           (hash (nthnext s2 120))
+           (hash (nthnext s3 120))))))
+
 ;; This problem reproduction code is slightly modified from a version
 ;; provided in a comment by Mike Fikes on 2018-Dec-09 for this issue:
 ;; https://clojure.atlassian.net/projects/CRRBV/issues/CRRBV-20

--- a/src/test/clojure/clojure/core/rrb_vector/test_common.clj
+++ b/src/test/clojure/clojure/core/rrb_vector/test_common.clj
@@ -9,6 +9,19 @@
 ;; library, this file and that one can be replaced with a common test
 ;; file with the suffix .cljc
 
+(deftest test-hasheq
+  (is (= (hash []) (hash (fv/vector))))  ;; CRRBV-25
+  (let [v1 (vec (range 1024))
+        v2 (vec (range 1024))
+        v3 (fv/catvec (vec (range 512)) (vec (range 512 1024)))
+        s1 (seq v1)
+        s2 (seq v2)
+        s3 (seq v3)]
+    (is (= (hash v1) (hash v2) (hash v3) (hash s1) (hash s2) (hash s3)))
+    (is (= (hash (nthnext s1 120))
+           (hash (nthnext s2 120))
+           (hash (nthnext s3 120))))))
+
 ;; This problem reproduction code is slightly modified from a version
 ;; provided in a comment by Mike Fikes on 2018-Dec-09 for this issue:
 ;; https://clojure.atlassian.net/projects/CRRBV/issues/CRRBV-20

--- a/src/test/clojure/clojure/core/rrb_vector_test.clj
+++ b/src/test/clojure/clojure/core/rrb_vector_test.clj
@@ -108,18 +108,6 @@
   (is (= (into (fv/catvec (vec (range 123)) (vec (range 68))) (range 64))
          (concat (range 123) (range 68) (range 64)))))
 
-(deftest test-hasheq
-  (let [v1 (vec (range 1024))
-        v2 (vec (range 1024))
-        v3 (fv/catvec (vec (range 512)) (vec (range 512 1024)))
-        s1 (seq v1)
-        s2 (seq v2)
-        s3 (seq v3)]
-    (is (= (hash v1) (hash v2) (hash v3) (hash s1) (hash s2) (hash s3)))
-    (is (= (hash (nthnext s1 120))
-           (hash (nthnext s2 120))
-           (hash (nthnext s3 120))))))
-
 (deftest test-iterators
   (let [v (fv/catvec (vec (range 1000)) (vec (range 1000 2048)))]
     (is (= (iterator-seq (.iterator ^Iterable v))


### PR DESCRIPTION
…ector

This was already OK for clj implementation, but cljs implementation
had mismatch.