### PR TITLE
Make new tests compatible with Clojure 1.5.1 and 1.6.0

### DIFF
--- a/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
+++ b/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
@@ -162,6 +162,8 @@
       (is (= (repeated-subvec-catvec 2371)
              (interleave (range 2371) (repeat 'x)))))))
 
+(def pos-infinity ##Inf)
+
 (deftest test-reduce-subvec-catvec2
   (let [my-catvec fv/catvec
         my-subvec fv/subvec]
@@ -171,8 +173,8 @@
             (repeated-subvec-catvec [i]
               (reduce insert-by-sub-catvec
                       (vec (range i))
-                      (take i (interleave (range (quot i 2) ##Inf)
-                                          (range (quot i 2) ##Inf)))))]
+                      (take i (interleave (range (quot i 2) pos-infinity)
+                                          (range (quot i 2) pos-infinity)))))]
       (let [n 2371
             v (repeated-subvec-catvec n)]
         (is (every? #(or (integer? %) (= 'x %)) v))

--- a/src/test/clojure/clojure/core/rrb_vector/test_common.clj
+++ b/src/test/clojure/clojure/core/rrb_vector/test_common.clj
@@ -162,6 +162,8 @@
       (is (= (repeated-subvec-catvec 2371)
              (interleave (range 2371) (repeat 'x)))))))
 
+(def pos-infinity Double/POSITIVE_INFINITY)
+
 (deftest test-reduce-subvec-catvec2
   (let [my-catvec fv/catvec
         my-subvec fv/subvec]
@@ -171,8 +173,8 @@
             (repeated-subvec-catvec [i]
               (reduce insert-by-sub-catvec
                       (vec (range i))
-                      (take i (interleave (range (quot i 2) ##Inf)
-                                          (range (quot i 2) ##Inf)))))]
+                      (take i (interleave (range (quot i 2) pos-infinity)
+                                          (range (quot i 2) pos-infinity)))))]
       (let [n 2371
             v (repeated-subvec-catvec n)]
         (is (every? #(or (integer? %) (= 'x %)) v))


### PR DESCRIPTION
which are still supported by core.rrb-vector, at least for now.