### PR TITLE
Clean up some test code

### DIFF
--- a/src/test/cljs/clojure/core/rrb_vector/test_cljs_basic.cljs
+++ b/src/test/cljs/clojure/core/rrb_vector/test_cljs_basic.cljs
@@ -8,9 +8,6 @@
 (defn format [& args]
   (apply gstring/format args))
 
-(deftest test-slicing
-  (is (dv/check-subvec 32000 10 29999 1234 18048 10123 10191)))
-
 (deftest test-slicing-generative
   (try (dv/generative-check-subvec 125 100000 10)
        (catch ExceptionInfo e
@@ -20,11 +17,6 @@
                                  (:s&es (ex-data e)))
                          {}
                          (ex-cause e))))))
-
-(deftest test-splicing
-  (is (dv/check-catvec 1025 1025 3245 1025 32768 1025 1025 10123 1025 1025))
-  (is (dv/check-catvec 10 40 40 40 40 40 40 40 40))
-  (is (apply dv/check-catvec (repeat 30 33))))
 
 (def medium-check-catvec-params [250 30 10 60000])
 (def short-check-catvec-params [10 30 10 60000])
@@ -39,73 +31,3 @@
                                  (:cnts (ex-data e)))
                          {}
                          (.getCause e))))))
-
-(deftest test-reduce
-  (let [v1 (vec (range 128))
-        v2 (fv/vec (range 128))]
-    (is (= (reduce + v1) (reduce + v2)))
-    (is (= (reduce-kv + 0 v1) (reduce-kv + 0 v2)))))
-
-(deftest test-seq
-  (let [v (fv/vec (range 128))
-        s (seq v)]
-    (is (= v s))
-    (is (chunked-seq? s))
-    (is (satisfies? IReduce s))))
-
-(deftest test-assoc
-  (let [v1 (fv/vec (range 40000))
-        v2 (reduce (fn [out [k v]]
-                     (assoc out k v))
-                   (assoc v1 40000 :foo)
-                   (map-indexed vector (rseq v1)))]
-    (is (= (concat (rseq v1) [:foo]) v2)))
-  (loop [i 1]
-    (if (< i 35000)
-      (let [v (-> (range 40000)
-                  (fv/vec)
-                  (fv/subvec i)
-                  (assoc 10 :foo))]
-        (is (= :foo (nth v 10)))
-        (recur (* i 32))))))
-
-(deftest test-assoc!
-  (let [v1 (fv/vec (range 40000))
-        v2 (persistent!
-            (reduce (fn [out [k v]]
-                      (assoc! out k v))
-                    (assoc! (transient v1) 40000 :foo)
-                    (map-indexed vector (rseq v1))))]
-    (is (= (concat (rseq v1) [:foo]) v2)))
-  (loop [i 1]
-    (if (< i 35000)
-      (let [v (-> (range 40000)
-                  (fv/vec)
-                  (fv/subvec i)
-                  (transient)
-                  (assoc! 10 :foo)
-                  (persistent!))]
-        (is (= :foo (nth v 10)))
-        (recur (* i 32))))))
-
-(deftest test-relaxed
-  (is (= (into (fv/catvec (vec (range 123)) (vec (range 68))) (range 64))
-         (concat (range 123) (range 68) (range 64))))
-  (is (= (dv/slow-into (fv/catvec (vec (range 123)) (vec (range 68)))
-                       (range 64))
-         (concat (range 123) (range 68) (range 64)))))
-
-(deftest test-splice-high-subtree-branch-count
-  (let [x        (fv/vec (repeat 1145 \a))
-        y        (fv/catvec (fv/subvec x 0 778) (fv/subvec x 778 779) [1] (fv/subvec x 779))
-        z        (fv/catvec (fv/subvec y 0 780) [2] (fv/subvec y 780 781) (fv/subvec y 781))
-        res      (fv/catvec (fv/subvec z 0 780) [] [3] (fv/subvec z 781))
-        expected (concat (repeat 779 \a) [1] [3] (repeat 366 \a))]
-    (is (= res expected))))
-
-(deftest test-reduce-subvec-catvec
-  (letfn [(insert-by-sub-catvec [v n]
-            (fv/catvec (fv/subvec v 0 n) (fv/vec ['x]) (fv/subvec v n)))
-          (repeated-subvec-catvec [i]
-            (reduce insert-by-sub-catvec (fv/vec (range i)) (range i 0 -1)))]
-    (is (= (repeated-subvec-catvec 2371) (interleave (range 2371) (repeat 'x))))))

--- a/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
+++ b/src/test/cljs/clojure/core/rrb_vector/test_common.cljs
@@ -15,9 +15,7 @@
   (testing "slicing"
     (is (dv/check-subvec 32000 10 29999 1234 18048 10123 10191))))
 
-;; TBD: Uncomment this test after I figure out which of my fixes gets
-;; it working again.
-#_(deftest test-splicing
+(deftest test-splicing
   (testing "splicing"
     (is (dv/check-catvec 1025 1025 3245 1025 32768 1025 1025 10123 1025 1025))
     (is (dv/check-catvec 10 40 40 40 40 40 40 40 40))
@@ -25,8 +23,11 @@
     (is (dv/check-catvec 26091 31388 1098 43443 46195 4484 48099 7905
                          13615 601 13878 250 10611 9271 53170))
 
+    ;; TBD: Uncomment the test code below after I figure out which of
+    ;; my fixes gets it working again.
+
     ;; Order that catvec will perform splicev calls:
-    (let [my-catvec fv/catvec
+    #_(let [my-catvec fv/catvec
           ;; Consider switching to the next line if we add
           ;; dv/dbg-splicev from branch into master.
           ;;my-catvec dv/dbg-splicev
@@ -225,9 +226,7 @@
     ;; This one causes a NullPointerException while traversing the seq
     (is (= (seq v4) (range bfactor-squared)))))
 
-;; TBD: Uncomment this test after I figure out which of my fixes gets
-;; it working again.
-#_(deftest test-npe-for-1025-then-pop!
+(deftest test-npe-for-1025-then-pop!
   (doseq [kind [:object-array]]
     (npe-for-1025-then-pop! kind)))
 

--- a/src/test/clojure/clojure/core/rrb_vector/test_common.clj
+++ b/src/test/clojure/clojure/core/rrb_vector/test_common.clj
@@ -15,9 +15,7 @@
   (testing "slicing"
     (is (dv/check-subvec 32000 10 29999 1234 18048 10123 10191))))
 
-;; TBD: Uncomment this test after I figure out which of my fixes gets
-;; it working again.
-#_(deftest test-splicing
+(deftest test-splicing
   (testing "splicing"
     (is (dv/check-catvec 1025 1025 3245 1025 32768 1025 1025 10123 1025 1025))
     (is (dv/check-catvec 10 40 40 40 40 40 40 40 40))
@@ -25,8 +23,11 @@
     (is (dv/check-catvec 26091 31388 1098 43443 46195 4484 48099 7905
                          13615 601 13878 250 10611 9271 53170))
 
+    ;; TBD: Uncomment the test code below after I figure out which of
+    ;; my fixes gets it working again.
+
     ;; Order that catvec will perform splicev calls:
-    (let [my-catvec fv/catvec
+    #_(let [my-catvec fv/catvec
           ;; Consider switching to the next line if we add
           ;; dv/dbg-splicev from branch into master.
           ;;my-catvec dv/dbg-splicev
@@ -195,7 +196,7 @@
   (let [bfactor-squared (* 32 32)
         mk-vector (case kind
                     :object-array fv/vector
-                    (:long-array #(fv/vector-of :long)))
+                    :long-array #(fv/vector-of :long))
         boundary 54
         v1 (-> (mk-vector)
                (into (range boundary))
@@ -226,9 +227,7 @@
     ;; This one causes a NullPointerException while traversing the seq
     (is (= (seq v4) (range bfactor-squared)))))
 
-;; TBD: Uncomment this test after I figure out which of my fixes gets
-;; it working again.
-#_(deftest test-npe-for-1025-then-pop!
+(deftest test-npe-for-1025-then-pop!
   (doseq [kind [:object-array :long-array]]
     (npe-for-1025-then-pop! kind)))
 


### PR DESCRIPTION
Uncomment several commented-out tests that are already passing.  One
portion of deftest test-splicing remains commented out because it does
not pass yet.

Remove tests from the following namespaces:

* clojure.core.rrb-vector.test-cljs-basic
* clojure.core.rrb-vector-test

that has since been temporarily duplicated in this namespace:

* clojure.core.rrb-vector.test-common

The first two namespaces still exist, and contain those tests that
have not been moved to the last namespace.