### PR TITLE
Add a function cvec to debug ns and use it in tests

### DIFF
--- a/src/main/cljs/clojure/core/rrb_vector/debug.cljs
+++ b/src/main/cljs/clojure/core/rrb_vector/debug.cljs
@@ -207,6 +207,27 @@
         i
         -1))))
 
+;; When using non-default parameters for the tree data structure,
+;; e.g. shift-increment not 5, then in test code with calls to
+;; checking-* functions, they will give errors if they are ever given
+;; a vector returned by clojure.core/vec, because without changes to
+;; Clojure itself, they always have shift-increment 5 and max-branches
+;; 32.
+;;
+;; If we use (fv/vec coll) consistently in the test code, that in many
+;; cases returns a core.rrb-vector data structure, but if given a
+;; Clojure vector, it still returns that Clojure vector unmodified,
+;; which has the same issues for checking-* functions.  By
+;; calling (fv/vec (seq coll)) when not using default parameters, we
+;; force the return value of cvec to always be a core.rrb-vector data
+;; structure.
+;;
+;; The name 'cvec' is intended to mean "construct a vector", and only
+;; intended for use in test code that constructs vectors used as
+;; parameters to other functions operating on vectors.
+(defn cvec [coll]
+  (clojure.core/vec coll))
+
 (defn slow-into [to from]
   (reduce conj to from))
 

--- a/src/main/clojure/clojure/core/rrb_vector/debug.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/debug.clj
@@ -207,6 +207,27 @@
         i
         -1))))
 
+;; When using non-default parameters for the tree data structure,
+;; e.g. shift-increment not 5, then in test code with calls to
+;; checking-* functions, they will give errors if they are ever given
+;; a vector returned by clojure.core/vec, because without changes to
+;; Clojure itself, they always have shift-increment 5 and max-branches
+;; 32.
+;;
+;; If we use (fv/vec coll) consistently in the test code, that in many
+;; cases returns a core.rrb-vector data structure, but if given a
+;; Clojure vector, it still returns that Clojure vector unmodified,
+;; which has the same issues for checking-* functions.  By
+;; calling (fv/vec (seq coll)) when not using default parameters, we
+;; force the return value of cvec to always be a core.rrb-vector data
+;; structure.
+;;
+;; The name 'cvec' is intended to mean "construct a vector", and only
+;; intended for use in test code that constructs vectors used as
+;; parameters to other functions operating on vectors.
+(defn cvec [coll]
+  (clojure.core/vec coll))
+
 (defn slow-into [to from]
   (reduce conj to from))
 

--- a/src/test/clojure/clojure/core/rrb_vector/long_test.clj
+++ b/src/test/clojure/clojure/core/rrb_vector/long_test.clj
@@ -64,4 +64,4 @@
 (deftest test-crrbv-17
   (utils/reset-optimizer-counts!)
   (is (= (reverse (range benchmark-size))
-         (vector-push-f (fv/vector) fv/catvec fv/catvec))))
+         (vector-push-f (fv/vector) fv/catvec dv/checking-catvec))))

--- a/src/test/clojure/clojure/core/rrb_vector/test_clj_only.clj
+++ b/src/test/clojure/clojure/core/rrb_vector/test_clj_only.clj
@@ -49,7 +49,7 @@
                                (.getCause e))))))))
 
 (deftest test-iterators
-  (let [v (fv/catvec (vec (range 1000)) (vec (range 1000 2048)))]
+  (let [v (fv/catvec (dv/cvec (range 1000)) (dv/cvec (range 1000 2048)))]
     (is (= (iterator-seq (.iterator ^Iterable v))
            (iterator-seq (.iterator ^Iterable (seq v)))
            (iterator-seq (.listIterator ^java.util.List v))


### PR DESCRIPTION
This enables using these tests with checking-* functions on
parameterized variations of the core.rrb-vector tree data structures
that limit their branching to other powers of 2, e.g. 8 or 16.  Such
smaller branch factors should enable generative tests to find more
interesting tests cases more quickly.