### PR TITLE
Add code to print Java classpath and shift-increment parameter

### DIFF
--- a/src/test/clojure/clojure/core/rrb_vector/test_infra.clj
+++ b/src/test/clojure/clojure/core/rrb_vector/test_infra.clj
@@ -1,5 +1,6 @@
 (ns clojure.core.rrb-vector.test-infra
-  (:require [clojure.test :as test]))
+  (:require [clojure.test :as test]
+            [clojure.string :as str]))
 
 (defn now-msec []
   (System/currentTimeMillis))
@@ -7,14 +8,31 @@
 (def num-deftests-started (atom 0))
 (def last-deftest-start-time (atom nil))
 
+(defn print-jvm-classpath []
+  (let [cp-str (System/getProperty "java.class.path")
+        cp-strs (str/split cp-str #":")]
+    (println "java.class.path:")
+    (doseq [cp-str cp-strs]
+      (println "  " cp-str))))
+
+(defn print-clj-jvm-info []
+  (try
+    (let [shift-var (resolve
+                     'clojure.core.rrb-vector.parameters/shift-increment)]
+      (println "shift-increment=" @shift-var " (from parameters namespace)"))
+    (catch Exception e
+      (println "shift-increment=5 (assumed because no parameters namespace)")))
+  (let [p (System/getProperties)]
+    (println "java.vm.name" (get p "java.vm.name"))
+    (println "java.vm.version" (get p "java.vm.version"))
+    (print-jvm-classpath)
+    (println "(clojure-version)" (clojure-version))))
+
 (defmethod test/report :begin-test-var
   [m]
   (let [n (swap! num-deftests-started inc)]
     (when (== n 1)
-      (let [p (System/getProperties)]
-        (println "java.vm.name" (get p "java.vm.name"))
-        (println "java.vm.version" (get p "java.vm.version"))
-        (println "(clojure-version)" (clojure-version)))))
+      (print-clj-jvm-info)))
   (println)
   (println "starting clj test" (:var m))
   (reset! last-deftest-start-time (now-msec)))


### PR DESCRIPTION
just before the first deftest is executed.  This cen be useful context
information to ensure that the classpath has been set as expected, and
any attempts to change the default data structure parameters have
taken effect.