### PR TITLE
Add parameters namespace

### DIFF
--- a/src/main/clojure/clojure/core/rrb_vector.clj
+++ b/src/main/clojure/clojure/core/rrb_vector.clj
@@ -32,7 +32,8 @@
   {:author "Michał Marczyk"}
 
   (:refer-clojure :exclude [vector vector-of vec subvec])
-  (:require [clojure.core.rrb-vector.protocols :refer [slicev splicev]]
+  (:require [clojure.core.rrb-vector.parameters :as p]
+            [clojure.core.rrb-vector.protocols :refer [slicev splicev]]
             [clojure.core.rrb-vector.nodes
              :refer [ams object-am object-nm primitive-nm
                      empty-pv-node empty-gvec-node]]

--- a/src/main/clojure/clojure/core/rrb_vector/debug.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/debug.clj
@@ -1,5 +1,6 @@
 (ns clojure.core.rrb-vector.debug
-  (:require [clojure.core.rrb-vector.rrbt
+  (:require [clojure.core.rrb-vector.parameters :as p]
+            [clojure.core.rrb-vector.rrbt
              :refer [as-rrbt]]
             [clojure.core.rrb-vector :as fv]
             [clojure.core.rrb-vector.rrbt :as rrbt]
@@ -240,7 +241,9 @@
 ;; intended for use in test code that constructs vectors used as
 ;; parameters to other functions operating on vectors.
 (defn cvec [coll]
-  (clojure.core/vec coll))
+  (if (= p/shift-increment 5)
+    (clojure.core/vec coll)
+    (fv/vec (seq coll))))
 
 (defn slow-into [to from]
   (reduce conj to from))
@@ -434,7 +437,7 @@
       {:error true, :kind :internal
        :description
        (str "Found internal regular node with # full + # partial=" num-non-nil
-            " children outside of range [1, 32]."
+            " children outside of range [1, " 32 "]."
             " root-node?=" root-node? " root-node-cnt=" root-node-cnt)
        :data children}
       :else

--- a/src/main/clojure/clojure/core/rrb_vector/debug_platform_dependent.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/debug_platform_dependent.clj
@@ -1,6 +1,7 @@
 (ns clojure.core.rrb-vector.debug-platform-dependent
   (:refer-clojure :exclude [format printf])
-  (:require clojure.core.rrb-vector.rrbt
+  (:require [clojure.core.rrb-vector.parameters :as p]
+            clojure.core.rrb-vector.rrbt
             [clojure.core.rrb-vector.nodes
              :refer [ranges object-nm primitive-nm object-am]]
             [clojure.core.rrb-vector :as fv])

--- a/src/main/clojure/clojure/core/rrb_vector/nodes.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/nodes.clj
@@ -1,4 +1,5 @@
 (ns clojure.core.rrb-vector.nodes
+  (:require [clojure.core.rrb-vector.parameters :as p])
   (:import (clojure.core VecNode ArrayManager)
            (clojure.lang PersistentVector PersistentVector$Node)
            (java.util.concurrent.atomic AtomicReference)))

--- a/src/main/clojure/clojure/core/rrb_vector/parameters.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/parameters.clj
@@ -1,0 +1,20 @@
+(ns clojure.core.rrb-vector.parameters)
+
+;; This namespace exists primarily so that the parameterized version
+;; of this code, and the 'production' version of this code, can be
+;; more similar to each other, by requiring this namespace from most
+;; of the other namespaces.
+
+;; Even though the values below are not used in most of the production
+;; code, they can serve a little bit as documentation of these
+;; parameter values.
+
+(def shift-increment 5)
+
+(def shift-increment-times-2 (* 2 shift-increment))
+(def max-branches (bit-shift-left 1 shift-increment))
+(def branch-mask (dec max-branches))
+(def max-branches-minus-1 (dec max-branches))
+(def max-branches-minus-2 (- max-branches 2))
+(def non-regular-array-len (inc max-branches))
+(def max-branches-squared (* max-branches max-branches))

--- a/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/rrbt.clj
@@ -1,6 +1,7 @@
 (ns clojure.core.rrb-vector.rrbt
   (:refer-clojure :exclude [assert ->VecSeq])
-  (:require [clojure.core.rrb-vector.protocols
+  (:require [clojure.core.rrb-vector.parameters :as p]
+            [clojure.core.rrb-vector.protocols
              :refer [PSliceableVector slicev
                      PSpliceableVector splicev
                      PTransientDebugAccess]]

--- a/src/main/clojure/clojure/core/rrb_vector/transients.clj
+++ b/src/main/clojure/clojure/core/rrb_vector/transients.clj
@@ -1,5 +1,6 @@
 (ns clojure.core.rrb-vector.transients
-  (:require [clojure.core.rrb-vector.nodes :refer [ranges last-range
+  (:require [clojure.core.rrb-vector.parameters :as p]
+            [clojure.core.rrb-vector.nodes :refer [ranges last-range
                                                    overflow?]])
   (:import (clojure.core.rrb_vector.nodes NodeManager)
            (clojure.core ArrayManager)
@@ -121,7 +122,7 @@
                                                (unchecked-subtract-int
                                                 shift 5))]
                           (aset ^objects arr subidx editable-child)
-                          (recur editable-child (- shift 5))))))))
+                          (recur editable-child (- shift (int 5)))))))))
               ret)
           (let [arr  (.array nm ret)
                 rngs (ranges nm ret)
@@ -303,7 +304,7 @@
             (let [arr (object-array 32)
                   ret (.node nm edit arr)]
               (aset ^objects arr 0 n)
-              (recur (unchecked-add s 5) ret))))
+              (recur (unchecked-add s (int 5)) ret))))
         (loop [s 0 n current-node]
           (if (== s shift)
             n
@@ -314,4 +315,4 @@
               (aset ^objects arr 32 rngs)
               (aset rngs 32 1)
               (aset rngs 0 (.alength am tail))
-              (recur (unchecked-add s 5) ret))))))))
+              (recur (unchecked-add s (int 5)) ret))))))))


### PR DESCRIPTION
This is not because the production version of the code really needs
such a namespace, but it does help the diff output between the
production version of the code and the soon-to-be-committed
parameterized version of the code have a smaller diff between them,
for quicker comparison of any differences they may have.